### PR TITLE
Export toggle and fix `className` clashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
+    "@types/uuid": "^8.3.4",
     "boring-avatars": "^1.5.8",
     "jest-styled-components": "^7.0.3",
     "lodash.throttle": "^4.1.1",
@@ -115,6 +116,7 @@
     "react-responsive-carousel": "^3.2.18",
     "react-responsive-tabs": "^4.4.1",
     "react-select": "^4.3.1",
-    "styled-components": "^5.2.1"
+    "styled-components": "^5.2.1",
+    "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "TAIKAI Design System",
   "license": "MIT",
   "repository": {

--- a/src/atoms/error-field/__tests__/__snapshots__/error-field.test.tsx.snap
+++ b/src/atoms/error-field/__tests__/__snapshots__/error-field.test.tsx.snap
@@ -2,20 +2,14 @@
 
 exports[`ErrorField renders 1`] = `
 <DocumentFragment>
-  .c1 {
+  .c0 {
   display: block;
   font-size: 0.7rem;
   color: #ef5766;
 }
 
-.styles__TextFieldInputStyle-sc-1jl38sp-0 + .c0,
-.sc-gsTCUz + .c1,
-.sc-hKgILt + .c1 {
-  margin-top: 0.3125rem;
-}
-
 <span
-    class="c0 c1 error-field"
+    class="c0 error-field"
     color="red"
   >
     operation failed.

--- a/src/atoms/slideshow/__tests__/__snapshots__/slideshow.test.tsx.snap
+++ b/src/atoms/slideshow/__tests__/__snapshots__/slideshow.test.tsx.snap
@@ -508,7 +508,7 @@ exports[`Slideshow renders 1`] = `
         >
           <ul
             class="slider animated"
-            style="transform: translate3d(-100%,0,0); transition-duration: 1000ms; height: auto;"
+            style="transform: translate3d(-100%,0,0); transition-duration: 1000ms;"
           >
             <li
               class="slide"
@@ -519,7 +519,7 @@ exports[`Slideshow renders 1`] = `
               />
             </li>
             <li
-              class="slide selected"
+              class="slide selected previous"
             >
               <img
                 alt="img"
@@ -543,7 +543,7 @@ exports[`Slideshow renders 1`] = `
               />
             </li>
             <li
-              class="slide selected"
+              class="slide selected previous"
             >
               <img
                 alt="img"

--- a/src/atoms/toggle/__tests__/toggle.test.tsx
+++ b/src/atoms/toggle/__tests__/toggle.test.tsx
@@ -108,4 +108,105 @@ describe(`${Toggle.name} atom`, () => {
     expect(labelOff).toBeChecked();
     expect(labelOff).toBeDisabled();
   });
+
+  it('instatiates (n) numbers of components without clashing each other', () => {
+    makeSut({
+      ...INITIAL_STATE,
+      isLabelVisible: true,
+      labelLeft: 'off',
+      labelRight: 'on',
+    });
+
+    makeSut({
+      ...INITIAL_STATE,
+      isLabelVisible: true,
+      labelLeft: 'off2',
+      labelRight: 'on2',
+    });
+
+    makeSut({
+      ...INITIAL_STATE,
+      isLabelVisible: true,
+      labelLeft: 'off3',
+      labelRight: 'on3',
+    });
+
+    const labelOff = screen.getByRole('radio', { name: 'off' });
+    const labelOn = screen.getByRole('radio', { name: 'on' });
+
+    const labelOff2 = screen.getByRole('radio', { name: 'off2' });
+    const labelOn2 = screen.getByRole('radio', { name: 'on2' });
+
+    const labelOff3 = screen.getByRole('radio', { name: 'off3' });
+    const labelOn3 = screen.getByRole('radio', { name: 'on3' });
+
+    ///#region Activating the states
+    // it tries do activate it (on) - 1st
+    userEvent.click(labelOn);
+    expect(mockOnClick).toBeCalledTimes(1);
+    expect(labelOn).toBeChecked();
+    expect(labelOff).not.toBeChecked();
+    // checks if the other components state are intact
+    expect(labelOn2).not.toBeChecked();
+    expect(labelOff2).toBeChecked();
+    expect(labelOn3).not.toBeChecked();
+    expect(labelOff3).toBeChecked();
+
+    // it tries do activate it (on) - 2nd
+    userEvent.click(labelOn2);
+    expect(mockOnClick).toBeCalledTimes(2);
+    expect(labelOn2).toBeChecked();
+    expect(labelOff2).not.toBeChecked();
+    // checks if the other components state are intact
+    expect(labelOn).toBeChecked();
+    expect(labelOff).not.toBeChecked();
+    expect(labelOn3).not.toBeChecked();
+    expect(labelOff3).toBeChecked();
+
+    // it tries do activate it (on) - 3rd
+    userEvent.click(labelOn3);
+    expect(mockOnClick).toBeCalledTimes(3);
+    expect(labelOn3).toBeChecked();
+    expect(labelOff3).not.toBeChecked();
+    // checks if the other components state are intact
+    expect(labelOn).toBeChecked();
+    expect(labelOff).not.toBeChecked();
+    expect(labelOn2).toBeChecked();
+    expect(labelOff2).not.toBeChecked();
+    ///#endregion
+
+    ///#region Disabling the states
+    // it tries do disactivate it (off) - 1st
+    userEvent.click(labelOff);
+    expect(mockOnClick).toBeCalledTimes(4);
+    expect(labelOn).not.toBeChecked();
+    expect(labelOff).toBeChecked();
+    // checks if the other components state are intact
+    expect(labelOn2).toBeChecked();
+    expect(labelOff2).not.toBeChecked();
+    expect(labelOn3).toBeChecked();
+    expect(labelOff3).not.toBeChecked();
+
+    // it tries do disactivate it (off) - 2nd
+    userEvent.click(labelOff2);
+    expect(mockOnClick).toBeCalledTimes(5);
+    expect(labelOn2).not.toBeChecked();
+    expect(labelOff2).toBeChecked();
+    // checks if the other components state are intact
+    expect(labelOn).not.toBeChecked();
+    expect(labelOff).toBeChecked();
+    expect(labelOn3).toBeChecked();
+    expect(labelOff3).not.toBeChecked();
+
+    // it tries do disactivate it (off) - 3rd
+    userEvent.click(labelOff3);
+    expect(mockOnClick).toBeCalledTimes(6);
+    expect(labelOn3).not.toBeChecked();
+    expect(labelOff3).toBeChecked();
+    // checks if the other components state are intact
+    expect(labelOn).not.toBeChecked();
+    expect(labelOff).toBeChecked();
+    expect(labelOn2).not.toBeChecked();
+    expect(labelOff2).toBeChecked();
+  });
 });

--- a/src/atoms/toggle/__tests__/toggle.test.tsx
+++ b/src/atoms/toggle/__tests__/toggle.test.tsx
@@ -10,6 +10,8 @@ const mockOnClick = jest.fn();
 const INITIAL_STATE: ToggleProps = {
   isLabelVisible: false,
   onClick: mockOnClick,
+  ariaLabelOn: 'on',
+  ariaLabelOff: 'off',
 };
 const makeSut = (args: ToggleProps = INITIAL_STATE) =>
   render(<Toggle {...args} />);
@@ -115,6 +117,8 @@ describe(`${Toggle.name} atom`, () => {
       isLabelVisible: true,
       labelLeft: 'off',
       labelRight: 'on',
+      ariaLabelOn: 'on',
+      ariaLabelOff: 'off',
     });
 
     makeSut({
@@ -122,6 +126,8 @@ describe(`${Toggle.name} atom`, () => {
       isLabelVisible: true,
       labelLeft: 'off2',
       labelRight: 'on2',
+      ariaLabelOn: 'on2',
+      ariaLabelOff: 'off2',
     });
 
     makeSut({
@@ -129,6 +135,8 @@ describe(`${Toggle.name} atom`, () => {
       isLabelVisible: true,
       labelLeft: 'off3',
       labelRight: 'on3',
+      ariaLabelOn: 'on3',
+      ariaLabelOff: 'off3',
     });
 
     const labelOff = screen.getByRole('radio', { name: 'off' });

--- a/src/atoms/toggle/index.tsx
+++ b/src/atoms/toggle/index.tsx
@@ -5,11 +5,13 @@ import { ToggleProps } from './types';
 import { v4 } from 'uuid';
 
 const Toggle = ({
-  isLabelVisible = false,
-  disabled = false,
-  checked = false,
+  ariaLabelOn,
+  ariaLabelOff,
   labelLeft = 'Off',
   labelRight = 'On',
+  checked = false,
+  disabled = false,
+  isLabelVisible = false,
   onClick = () => {},
   ...rest
 }: ToggleProps) => {
@@ -54,6 +56,7 @@ const Toggle = ({
             name={`toggle-id-${id}`}
             id={`${id}-switch-off`}
             className="switch-off"
+            aria-label={ariaLabelOff}
             disabled={disabled}
             aria-checked={!state}
             defaultChecked={!checked}
@@ -64,6 +67,7 @@ const Toggle = ({
             name={`toggle-id-${id}`}
             className="switch-on"
             id={`${id}-switch-on`}
+            aria-label={ariaLabelOn}
             disabled={disabled}
             aria-checked={state}
             defaultChecked={checked}

--- a/src/atoms/toggle/index.tsx
+++ b/src/atoms/toggle/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import * as Styles from './styles';
 import { ToggleProps } from './types';
+import { v4 } from 'uuid';
 
 const Toggle = ({
   isLabelVisible = false,
@@ -14,6 +15,7 @@ const Toggle = ({
 }: ToggleProps) => {
   // tracks the active state so it's easier to test
   const [state, setState] = useState(checked);
+  const [id, setId] = useState('');
 
   const handleClick = (value: boolean) => {
     if (disabled) return;
@@ -21,6 +23,18 @@ const Toggle = ({
     setState(value);
     return onClick(value);
   };
+
+  useEffect(() => {
+    // If the ID stays outside the component
+    // it will be the same if we instantiate
+    // thousands components.
+    // And if it stays inside the component
+    // it will rerun everytime causing memory leak
+    // So, this will enforce a unique id,
+    // without any re-renders
+    const id = v4().split('', 5).join('');
+    setId(id);
+  }, []);
 
   return (
     <Styles.Switcher
@@ -30,14 +44,15 @@ const Toggle = ({
     >
       <div {...rest}>
         {labelLeft && isLabelVisible && (
-          <label htmlFor="switch-off">{labelLeft}</label>
+          <label htmlFor={`${id}-switch-off`}>{labelLeft}</label>
         )}
 
         <span className="wrapper">
           <input
             type="radio"
-            name="theme"
-            id="switch-off"
+            name={`toggle-id-${id}`}
+            id={`${id}-switch-off`}
+            className="switch-off"
             disabled={disabled}
             aria-checked={!state}
             defaultChecked={!checked}
@@ -45,8 +60,9 @@ const Toggle = ({
           />
           <input
             type="radio"
-            name="theme"
-            id="switch-on"
+            name={`toggle-id-${id}`}
+            className="switch-on"
+            id={`${id}-switch-on`}
             disabled={disabled}
             aria-checked={state}
             defaultChecked={checked}
@@ -57,12 +73,12 @@ const Toggle = ({
           <label
             aria-hidden="true"
             className="switcher"
-            htmlFor={`switch-${state ? 'off' : 'on'}`}
+            htmlFor={`${id}-switch-${state ? 'off' : 'on'}`}
           />
         </span>
 
         {labelRight && isLabelVisible && (
-          <label htmlFor="switch-on">{labelRight}</label>
+          <label htmlFor={`${id}-switch-on`}>{labelRight}</label>
         )}
       </div>
     </Styles.Switcher>

--- a/src/atoms/toggle/index.tsx
+++ b/src/atoms/toggle/index.tsx
@@ -41,8 +41,9 @@ const Toggle = ({
       disabled={disabled}
       role="radiogroup"
       aria-label="toggle switcher"
+      {...rest}
     >
-      <div {...rest}>
+      <div>
         {labelLeft && isLabelVisible && (
           <label htmlFor={`${id}-switch-off`}>{labelLeft}</label>
         )}

--- a/src/atoms/toggle/index.tsx
+++ b/src/atoms/toggle/index.tsx
@@ -38,6 +38,10 @@ const Toggle = ({
     setId(id);
   }, []);
 
+  useEffect(() => {
+    setState(checked);
+  }, [checked]);
+
   return (
     <Styles.Switcher
       disabled={disabled}
@@ -56,22 +60,22 @@ const Toggle = ({
             name={`toggle-id-${id}`}
             id={`${id}-switch-off`}
             className="switch-off"
-            aria-label={ariaLabelOff}
+            checked={!state}
             disabled={disabled}
             aria-checked={!state}
-            defaultChecked={!checked}
-            onClick={() => handleClick(false)}
+            aria-label={ariaLabelOff}
+            onChange={() => handleClick(false)}
           />
           <input
             type="radio"
             name={`toggle-id-${id}`}
             className="switch-on"
             id={`${id}-switch-on`}
-            aria-label={ariaLabelOn}
+            checked={state}
             disabled={disabled}
             aria-checked={state}
-            defaultChecked={checked}
-            onClick={() => handleClick(true)}
+            aria-label={ariaLabelOn}
+            onChange={() => handleClick(true)}
           />
           <span aria-hidden="true" className="bg" />
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}

--- a/src/atoms/toggle/styles.tsx
+++ b/src/atoms/toggle/styles.tsx
@@ -25,7 +25,7 @@ export const Switcher = styled.fieldset`
     .wrapper {
       display: inline-block;
       vertical-align: middle;
-      width: ${rem('48px')};
+      width: ${rem('40px')};
       height: ${rem('24px')};
       border-radius: 999px;
       border: 2px solid ${light};
@@ -49,7 +49,7 @@ export const Switcher = styled.fieldset`
 
         &.switch-on:checked ~ .switcher {
           right: 0;
-          left: calc(50% + ${rem('4px')});
+          left: 50%;
         }
 
         &.switch-on:checked ~ .bg {

--- a/src/atoms/toggle/styles.tsx
+++ b/src/atoms/toggle/styles.tsx
@@ -47,20 +47,20 @@ export const Switcher = styled.fieldset`
         position: relative;
         z-index: 1;
 
-        &#switch-on:checked ~ .switcher {
+        &.switch-on:checked ~ .switcher {
           right: 0;
           left: calc(50% + ${rem('4px')});
         }
 
-        &#switch-on:checked ~ .bg {
+        &.switch-on:checked ~ .bg {
           background-color: ${green};
         }
 
-        &#switch-off:checked ~ .switcher {
+        &.switch-off:checked ~ .switcher {
           right: 0;
         }
 
-        &#switch-off:checked ~ .bg {
+        &.switch-off:checked ~ .bg {
           background-color: ${lightGrey};
         }
       }
@@ -89,6 +89,7 @@ export const Switcher = styled.fieldset`
         border-radius: 999px;
         background-color: transparent;
         transition: all 0.3s ease-out;
+        background-color: ${lightGrey};
       }
     }
   }

--- a/src/atoms/toggle/types.ts
+++ b/src/atoms/toggle/types.ts
@@ -13,4 +13,6 @@ export interface ToggleProps
   disabled?: boolean;
   /** Activates or disactivates the labels */
   isLabelVisible: boolean;
+  ariaLabelOn?: string;
+  ariaLabelOff?: string;
 }

--- a/src/atoms/toggle/types.ts
+++ b/src/atoms/toggle/types.ts
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from 'react';
 
 export interface ToggleProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> {
+  extends Omit<HTMLAttributes<HTMLFieldSetElement>, 'onClick'> {
   /** The value that is called
    * when one of the fields is clicked
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export { default as TruncateLine } from './atoms/truncate-line';
 export { default as Slideshow } from './atoms/slideshow';
 export { default as VideoPlayer } from './atoms/video-player';
 export { default as ProgressBar } from './atoms/progress-bar';
+export { default as Toggle } from './atoms/toggle';
 
 // Molecules
 export { default as ActionsMenu } from './molecules/actions-menu';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,6 +3100,11 @@
   "resolved" "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz"
   "version" "2.0.6"
 
+"@types/uuid@^8.3.4":
+  "integrity" "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+  "resolved" "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz"
+  "version" "8.3.4"
+
 "@types/webpack-env@^1.16.0":
   "integrity" "sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw=="
   "resolved" "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.3.tgz"


### PR DESCRIPTION
The classNames, Ids and the input name were clashing. Thus, when having multiple instances of the toggle, when activating one it would disable the other and hide it (weird, right? lol)

So, this is the fix I found. IDK if using a `<form>` could be the solution. 🤔 